### PR TITLE
Setup automated phenopacket generation on release

### DIFF
--- a/.github/workflows/package_phenopackets.yml
+++ b/.github/workflows/package_phenopackets.yml
@@ -10,7 +10,7 @@ env:
   # Path to directory that contains the cohorts, one cohort per folder.
   NOTEBOOK_DIR: notebooks
   # How shall we name the archive with all phenopackets?
-  PHENOPACKET_ARCHIVE_NAME: phenopackets.${{ github.ref_name }}
+  PHENOPACKET_ARCHIVE_NAME: phenopackets
 
   # Run n jobs at the same time
   N_JOBS: 2

--- a/.github/workflows/package_phenopackets.yml
+++ b/.github/workflows/package_phenopackets.yml
@@ -53,6 +53,6 @@ jobs:
       - name: Upload the phenopacket archive
         uses: actions/upload-artifact@v4
         with:
-          name: phenopackets
+          name: phenopacket-store
           path: phenopackets.zip
           retention-days: 7

--- a/.github/workflows/package_phenopackets.yml
+++ b/.github/workflows/package_phenopackets.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4.3.1
         with:
-          python-version: "3.10.0"
+          python-version: '3.10'
 
       - name: Install the phenopacket-store package
         run: |

--- a/.github/workflows/package_phenopackets.yml
+++ b/.github/workflows/package_phenopackets.yml
@@ -48,11 +48,11 @@ jobs:
 
       - name: Package the phenopackets
         run: |
-          python3 -m ppktstore package --notebook-dir "${NOTEBOOK_DIR}" --output "${PHENOPACKET_ARCHIVE_NAME}"
+          python3 -m ppktstore package --notebook-dir "${NOTEBOOK_DIR}" --output phenopackets
 
       - name: Upload the phenopacket archive
         uses: actions/upload-artifact@v4
         with:
-          name: ${PHENOPACKET_ARCHIVE_NAME}
-          path: ${PHENOPACKET_ARCHIVE_NAME}.zip
+          name: phenopackets
+          path: phenopackets.zip
           retention-days: 7

--- a/.github/workflows/package_phenopackets.yml
+++ b/.github/workflows/package_phenopackets.yml
@@ -9,8 +9,6 @@ on:
 env:
   # Path to directory that contains the cohorts, one cohort per folder.
   NOTEBOOK_DIR: notebooks
-  # How shall we name the archive with all phenopackets?
-  PHENOPACKET_ARCHIVE_NAME: phenopackets
 
   # Run n jobs at the same time
   N_JOBS: 2

--- a/.github/workflows/package_phenopackets.yml
+++ b/.github/workflows/package_phenopackets.yml
@@ -16,17 +16,15 @@ env:
   N_JOBS: 2
   KERNEL_NAME: pp_venv
 
-permissions:
-  contents: write
 jobs:
   generate-phenopackets:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4.3.1
         with:
-          python-version: "3.10"
+          python-version: "3.10.0"
 
       - name: Install the phenopacket-store package
         run: |

--- a/.github/workflows/package_phenopackets.yml
+++ b/.github/workflows/package_phenopackets.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Package the phenopackets
         run: |
-          python3 -m ppktstore package --notebooks "${NOTEBOOK_DIR}" --output "${PHENOPACKET_ARCHIVE_NAME}"
+          python3 -m ppktstore package --notebook-dir "${NOTEBOOK_DIR}" --output "${PHENOPACKET_ARCHIVE_NAME}"
 
       - name: Upload the phenopacket archive
         uses: actions/upload-artifact@v4

--- a/src/ppktstore/__main__.py
+++ b/src/ppktstore/__main__.py
@@ -5,7 +5,7 @@ import sys
 import ppktstore
 
 
-def main(argv):
+def main(argv) -> int:
     """
     Phenopacket-store CLI
     """
@@ -81,4 +81,4 @@ def setup_logging():
 
 
 if __name__ == '__main__':
-    main(sys.argv[1:])
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
The PR does 2 things:
- adds CLI to `ppktstore` package :
- sets up Github action to build a ZIP file with all phenopackets upon a release.

# CLI

The CLI allows us to use `ppktstore` code from terminal, without notebooks. This is useful if we want to run the code e.g. from GitHub action.

The CLI is run as:
```
python3 -m ppktstore --help
```

Currently, we have `package` command that takes a folder to the notebook/cohorts directory and creates a phenopacket ZIP at a desired location.

# Automated packaging

The `ppktstore package` is used by a new GitHub Action to create a ZIP in each release.

---

@pnrobinson I think this is useful and can be further extended to actually generate the phenopackets from the notebooks. However, the generation would not work now without updating the notebooks. We can improve this later.