### PR TITLE
Enhanced phenopacket for CARD9-deficient patient with additional phenotypes

### DIFF
--- a/notebooks/CARD9/phenopackets/PMID_26044242_24-year-oldCaucasianmale.json
+++ b/notebooks/CARD9/phenopackets/PMID_26044242_24-year-oldCaucasianmale.json
@@ -25,7 +25,8 @@
       "type": {
         "id": "HP:0032515",
         "label": "Deep dermatophytosis"
-      }
+      },
+      "description": "Trichophyton mentagrophytes isolated from skin lesions"
     },
     {
       "type": {
@@ -37,25 +38,75 @@
       "type": {
         "id": "HP:0003212",
         "label": "Increased circulating IgE level"
-      }
+      },
+      "description": "IgE >2000 UI/L"
     },
     {
       "type": {
         "id": "HP:0001880",
         "label": "Eosinophilia"
-      }
+      },
+      "description": "1368 cells/mm³ (17%)"
     },
     {
       "type": {
         "id": "HP:0003237",
         "label": "Increased circulating IgG level"
-      }
+      },
+      "description": "2120 mg/dL (normal range: 770-1510 mg/dL)"
     },
     {
       "type": {
         "id": "HP:0001888",
         "label": "Lymphopenia"
       }
+    },
+    {
+      "type": {
+        "id": "HP:0001596",
+        "label": "Alopecia"
+      },
+      "description": "Semi alopecia observed during clinical examination"
+    },
+    {
+      "type": {
+        "id": "HP:0200042",
+        "label": "Skin ulcer"
+      },
+      "description": "Ulcerative, secretive and painful lesions starting in the face at age 12 and later spreading to back (15 cm diameter) and shoulders",
+      "onset": {
+        "age": {
+          "iso8601duration": "P12Y"
+        }
+      }
+    },
+    {
+      "type": {
+        "id": "HP:0001581",
+        "label": "Recurrent skin infections"
+      },
+      "description": "Persistent dermatophyte infections with only transient improvement after multiple antifungal treatments"
+    },
+    {
+      "type": {
+        "id": "HP:0040218",
+        "label": "Reduced natural killer cell count"
+      },
+      "description": "Low numbers of NK (CD16+/CD56+) cells: 20 cells/mm³ (normal range: 82-760 cells/mm³)"
+    },
+    {
+      "type": {
+        "id": "HP:0002972",
+        "label": "Reduced delayed hypersensitivity"
+      },
+      "description": "Negative delayed-type hypersensitivity skin test for Candidin"
+    },
+    {
+      "type": {
+        "id": "HP:0002841",
+        "label": "Recurrent fungal infections"
+      },
+      "description": "Persistent fungal infections since age 3, including oral candidiasis and later dermatophytosis, with only transient response to multiple antifungal treatments"
     },
     {
       "type": {


### PR DESCRIPTION

This commit enhances the phenopacket for the CARD9-deficient patient in PMID:26044242 by adding six additional phenotypic features that were described in the original paper but not captured in the phenopacket:

1. Alopecia (HP:0001596)
   - Text evidence: \"At the same time, he lost his hair\" and \"Semi alopecia and onycodystrophy were observed (Fig. 1)\"

2. Skin ulcer (HP:0200042)
   - Text evidence: \"At 12 years, ulcerative, secretive and painful lesions installed in the face (lips) and spread to all the mandibular area\" and \"In the following years, the lesions increased affecting his back (15 cm of diameter) and shoulders\"

3. Recurrent skin infections (HP:0001581)
   - Text evidence: \"Transient improvement was observed after each therapeutic agent\" despite multiple antifungal treatments over years

4. Reduced natural killer cell count (HP:0040218)
   - Text evidence: \"Immunophenotyping showed normal CD4+ and CD8+ T and CD19+ lymphocyte counts and low numbers of NK (CD16+/CD56+) cells\" and from Table 1: \"CD16+ CD56+ (cells/mm3): 20\" (normal range: 82-760)

5. Reduced delayed hypersensitivity (HP:0002972)
   - Text evidence: \"Delayed-type hypersensitivity skin tests were negative for Candidin and of 8 mm for Trychophitin\"

6. Recurrent fungal infections (HP:0002841)
   - Text evidence: Multiple treatments over years for fungal infections. \"The symptoms started with oral candidiasis when he was 3 years old, persistent although treated\" and later development of dermatophytosis despite multiple antifungal treatments

Additionally, this commit adds descriptive text to provide clinical context for both existing and new phenotypes, including specific laboratory values and disease progression details.

Patient summary: A 24-year-old Brazilian Caucasian male with immunodeficiency 103/susceptibility to fungal infections due to a homozygous CARD9 R101L mutation. He presented with chronic oral candidiasis from age 3, followed by deep dermatophytosis and extensive skin involvement. Multiple antifungal treatments yielded only transient improvements.

I am an agent suggesting changes to phenopackets based on a careful reading of the full text of PMID:26044242. I used OAK to query for appropriate HPO terms, selecting terms that most accurately represent the phenotypes described in the source publication. I hope these improvements are helpful for a more complete clinical representation. Please provide feedback if I missed anything or if any terms could be improved.

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>