### PR TITLE
Explain updating the HPO version

### DIFF
--- a/HOW_TO_RELEASE.md
+++ b/HOW_TO_RELEASE.md
@@ -5,12 +5,13 @@ Follow this document to make new Phenopacket store release.
 ## Release checklist
 
 1. Start on the `main` branch.
-2. Ensure the `main` branch is clean with no uncommitted changes.
-3. If required, install [phenopacket-store-toolkit](https://github.com/monarch-initiative/phenopacket-store-toolkit).
+2. Consider updating the HPO version, as described in the [Update the HPO version](https://monarch-initiative.github.io/phenopacket-store/developers/#update-the-hpo-version) section.
+3. Ensure the `main` branch is clean with no uncommitted changes.
+4. If required, install [phenopacket-store-toolkit](https://github.com/monarch-initiative/phenopacket-store-toolkit).
     ```shell
     python3 -m pip install phenopacket-store-toolkit[release]
     ```
-4. Generate release archives with `ppktstore` CLI. 
+5. Generate release archives with `ppktstore` CLI. 
    For instance, run the following to generate a release `0.1.25`:
     ```shell
     python3 -m ppktstore package --notebook-dir notebooks --release-tag 0.1.25 --output all_phenopackets
@@ -18,15 +19,15 @@ Follow this document to make new Phenopacket store release.
   
     This will pack all phenopackets found in `notebooks` folder into `all_phenopackets.zip` ZIP file. 
     The ZIP file includes a top-level folder that corresponds to the used release tag (e.g. `0.1.25` in this case).
-5. Run the `PhenopacketStoreStats` notebook to update the stats (after updating the release_tag variable).
-6. Commit the changes in the notebook.
-7. Push the commits to GitHub.
-8. Go to [Releases](https://github.com/monarch-initiative/phenopacket-store/releases) and click on *Draft a new release* button to start making a new release
-9. Click on *Choose a tag* dropdown, type the release in (e.g. `0.1.25`), and click on *Create new tag on publish* (**IMPORTANT!**).
+6. Run the `PhenopacketStoreStats` notebook to update the stats (after updating the release_tag variable).
+7. Commit the changes in the notebook.
+8. Push the commits to GitHub.
+9. Go to [Releases](https://github.com/monarch-initiative/phenopacket-store/releases) and click on *Draft a new release* button to start making a new release
+10. Click on *Choose a tag* dropdown, type the release in (e.g. `0.1.25`), and click on *Create new tag on publish* (**IMPORTANT!**).
   ![Choose a tag](img/choose_a_tag.png)
-10. Click on *Generate release notes* button to add what's changed into the release notes.
-11. Attach the release archive generated in the 4th step by dragging it into the area located below the release notes.
-12. Click *Publish release* to make the release.
+11. Click on *Generate release notes* button to add what's changed into the release notes.
+12. Attach the release archive generated in the 4th step by dragging it into the area located below the release notes.
+13. Click *Publish release* to make the release.
 
 
 Done!

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -76,3 +76,50 @@ python3 -m ipykernel install --user --name ${ENV_NAME} --display-name "Phenopack
 After the installation, a new kernel called `Phenopacket Store Env` should be available in Jupyter. 
 Use the kernel to run the notebooks at will Make sure to choose the kernel when running the notebooks 
 in the [notebooks](https://github.com/monarch-initiative/phenopacket-store/tree/main/notebooks){:target="_blank"} folder.
+
+## Update the HPO version
+
+The Phenopacket Store Q/C pipeline uses HPO to prevent usage of the obsolete terms, the annotation consistency, and several other checks.
+The checks are run using a specific HPO release.
+
+The HPO version should be updated periodically to keep Phenopacket Store up-to-date. However, the version update can lead to Q/C issues that were not present with the older HPO. Therefore, the versions should be updated within a pull request (PR) that addresses all the Q/C issues. Here we show how to do this in a shell script.
+
+We will need a terminal window with Python 3.12 or better.
+
+To start, we install the [phenopacket-store-toolkit](https://github.com/monarch-initiative/phenopacket-store-toolkit) package.
+
+```shell
+python3 -m pip install phenopacket-store-toolkit[release]
+```
+
+The package performs the Q/C with an HPO release of interest (e.g. `v2026-06-23` in this example):
+
+```shell
+python3 -m ppktstore qc --notebook-dir notebooks --hpo-release v2026-06-23
+```
+> The HPO version must correspond to one of the HPO release tags
+> listed on the [HPO release](https://github.com/obophenotype/human-phenotype-ontology/tags) site.
+
+The `qc` command scans the notebook directory for the phenopackets, runs the Q/C, and displays the errors and warnings in the terminal.
+An example output is listed here:
+
+```
+▸ notebooks
+  ▸ SEC61A1
+    ▸ 4
+      ▸ phenotypic_features
+          errors:
+          • annotation to Gingivitis [HP:0000230] (#11) is redundant due to annotation to Recurrent gingivitis [HP:0034284] (#7)
+  ▸ RFXAP
+    ▸ 2
+      ▸ phenotypic_features
+        ▸ 6
+          ▸ type
+            ▸ id
+                errors:
+                • `HP:0003347` has been deprecated
+```
+
+Two issues are reported. The first issue describes a redundant phenotypic feature in the phenopacket `4` from the `SEC61A1` cohort and
+the second issue points out the usage of a deprecated HPO term in the 6th phenotypic feature of the phenopacket `2` of the `RFXAP` cohort.
+At this point, fixing the issues is the responsibility of the curator.


### PR DESCRIPTION
Describe how to update the HPO version of the Phenopacket Store.

A new section regading HPO bumping is added into the developers' documentation and bumping the HPO version is suggested in the release checklist.

Fix #182 